### PR TITLE
fix(LibCurl): change $host to astronomer endpoint

### DIFF
--- a/lib/Segment/Consumer/LibCurl.php
+++ b/lib/Segment/Consumer/LibCurl.php
@@ -38,7 +38,7 @@ class Segment_Consumer_LibCurl extends Segment_QueueConsumer {
     if ($this->host)
       $host = $this->host;
     else
-      $host = "api.segment.io";
+      $host = "api.astronomer.io";
     $path = "/v1/import";
     $url = $protocol . $host . $path;
 


### PR DESCRIPTION
since Lib_curl is the default consumer, we should set the `$host` to an astronomer endpoint